### PR TITLE
Profile options

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,6 +29,10 @@ export const SITE_NAME_PROPERTY = 'siteName';
 export const SITE_DESCRIPTION_PROPERTY = 'siteDescription';
 export const SITE_IMAGE_CID_PROPERTY = 'siteImageCid';
 
+// User profile properties
+export const PROFILE_NAME_PROPERTY = 'profileName';
+export const PROFILE_NAME_LANGUAGE_PROPERTY = 'language';
+
 export const SYNC_SITE_TARGET_ID_PROPERTY = 'targetSiteId';
 export const SYNC_SITE_STATUS_PROPERTY = 'status';
 export const SYNC_SITE_LAST_SYNC_PROPERTY = 'lastSync';


### PR DESCRIPTION
This is an experiment in progress with profile options. To consider for merging later...

Todos :
- [ ] Profile photo (document store?)
- [ ] Profile bio
- [ ] Profile contacts? (Limit read access to administrators?)
- [ ] Figure out how to incorporate this (which will be unique for each user) with the single Site program. (Unless, of course, we decide to turn the Site program into a swarm with user-level databases as well.) Perhaps incorporate into the general LensService, or else create a separate UserService
- [ ] Incorporate userId into the Site program database to track who added which release (perhaps as a separate PR).