### PR TITLE
feat(auth): Refactor ACLs with service layer pattern and add grant/revoke API

### DIFF
--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1,10 +1,10 @@
 import type { WithContext } from '@peerbit/document';
 import type { Site } from '../programs/site/program';
-import type { 
-  AccountType, 
-  BaseData, 
-  FeaturedReleaseData, 
-  ReleaseData, 
+import type {
+  AccountType,
+  BaseData,
+  FeaturedReleaseData,
+  ReleaseData,
   SiteArgs,
 } from '../programs/site/types';
 import type { FeaturedRelease, Release, Subscription } from '../programs/site/schemas';
@@ -27,7 +27,7 @@ export interface ILensService {
   init: (directory?: string) => Promise<void>;
   stop: () => Promise<void>;
   openSite: (siteOrAddress: Site | string, options?: { siteArgs?: SiteArgs, federate?: boolean }) => Promise<void>;
-  getAccountStatus: () => Promise<AccountType>;
+  getAccountStatus: (options?: { cached?: boolean }) => Promise<AccountType>;
   getRelease: (id: string) => Promise<WithContext<Release> | undefined>;
   getReleases: (options?: SearchOptions) => Promise<WithContext<Release>[]>;
   getFeaturedRelease: (id: string) => Promise<WithContext<FeaturedRelease> | undefined>;
@@ -42,4 +42,6 @@ export interface ILensService {
   getSubscriptions: (options?: SearchOptions) => Promise<Subscription[]>;
   addSubscription: (data: BaseData) => Promise<HashResponse>;
   deleteSubscription: (data: Partial<Pick<BaseData, 'id' | 'siteAddress'>>) => Promise<IdResponse>;
+  grantAccess(accountType: AccountType, publicKey: string): Promise<BaseResponse>;
+  revokeAccess(accountType: AccountType, publicKey: string): Promise<BaseResponse>;
 }

--- a/tests/federation.e2e.test.ts
+++ b/tests/federation.e2e.test.ts
@@ -45,7 +45,6 @@ import { waitForResolved } from '@peerbit/time';
           categoryId: 'benchmark-historical',
           contentCID: `cid_historical_${i}`,
           postedBy: serviceA.peerbit!.identity.publicKey,
-          siteAddress: siteAAddress,
         });
       }
 
@@ -74,7 +73,6 @@ import { waitForResolved } from '@peerbit/time';
         categoryId: 'benchmark-live',
         contentCID: 'cid_live_update',
         postedBy: serviceA.peerbit!.identity.publicKey,
-        siteAddress: siteAAddress,
       });
       
       const expectedSize = initialSize + 1;


### PR DESCRIPTION

This pull request introduces a major architectural refactoring of the Access Control Layer (ACL) and exposes user permission management through the `LensService`.

The primary motivation is to adhere to a strict service layer pattern, where the `LensService` acts as the sole, secure, and user-friendly entry point for all SDK operations. Previously, permission-related logic was either missing from the public API or required direct, low-level interaction with the `Site` program, breaking abstraction.

This PR addresses these issues by:
1.  **Introducing a full Grant/Revoke API** for administrators via the `LensService`.
2.  **Refactoring internal program logic** to be safer and more encapsulated.
3.  **Improving error handling** to distinguish between expected permission failures and unexpected system errors.
4.  **Enhancing the test suite** to be more robust, isolated, and precise in its assertions.

### **Key Changes**

#### 1. New Access Control API in `LensService`

The `ILensService` interface and its implementation have been extended with two new administrative methods:

*   **`grantAccess(accountType, publicKey)`:** Allows a site admin to grant `MEMBER` or `ADMIN` roles to another user.
*   **`revokeAccess(accountType, publicKey)`:** Allows a site admin to revoke a user's permissions. This includes important safety checks, such as preventing a user from revoking their own access.

These methods provide a clean, high-level API for what was previously a manual, low-level operation, significantly improving the developer experience.

#### 2. Encapsulation of `Site` Program Logic

The core `authorise` and `revoke` logic has been moved to internal-only methods (`_authorise`, `_revoke`) on the `Site` program.

*   **Why?** This enforces the service layer pattern. Developers are now guided to use the safe, validated `LensService.grantAccess()` method instead of directly manipulating the program's state. The `_` prefix clearly signals that these are internal, low-level functions.

#### 3. Centralized `findAccessGrant` Utility

A new, reusable helper function, `findAccessGrant`, has been created in `common/utils.ts`.

*   **Why?** The logic for searching an ACL store for a user's permission grant was duplicated in both the permission checking (`_canPerformCheck`) and revocation (`_revoke`) code. This new utility centralizes this logic, reducing code duplication and making the implementation cleaner and more maintainable.

#### 4. Intelligent Error Handling

The `catch` blocks in all permission-gated `LensService` methods have been updated to be more discerning.

*   **Why?** Previously, any thrown error (including expected `AccessError`s from permission checks) was logged as a critical failure, creating excessive noise in test outputs and logs. The new logic now correctly identifies `AccessError` as an expected operational failure and only logs truly unexpected system errors. This makes debugging far more effective.

#### 5. Robust and Isolated ACL Test Suite (`acl.test.ts`)

The ACL test suite has been significantly improved:

*   **Test Isolation:** The test for granting/revoking access now creates a temporary, ephemeral user identity. This prevents the test from altering the state of the shared `memberClient`, which caused flakiness and order-dependent failures in the previous implementation.
*   **Precise Assertions:** Tests that expect a permission failure now assert for the exact error message (`"Access denied"`) returned by the service layer, rather than using a generic `toContain`. This makes the tests stricter and more reliable.

### **How to Review**

1.  Start with **`src/services/types.ts`** to see the new `grantAccess` and `revokeAccess` methods on the `ILensService` interface.
2.  Review **`src/services/lens.ts`** to see the implementation of these new methods and the improved error handling logic in the `catch` blocks. Note the refactoring of `_canPerformCheck`.
3.  Examine **`src/programs/site/program.ts`** to see how `authorise` and `revoke` have been refactored into internal `_` methods.
4.  Look at the new **`findAccessGrant`** function in `src/common/utils.ts` to understand the centralized utility.
5.  Finally, review **`tests/acl.test.ts`** to see how the new, more robust testing strategy is implemented, particularly the isolated grant/revoke test and the stricter error assertions.

This PR represents a significant step forward in the SDK's maturity, providing a more secure, usable, and maintainable foundation for developers.