### PR TITLE
feat(site): Implement full CRUD and management for Content Categories

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@peerbit/stream-interface": "^5.2.3",
     "@peerbit/time": "^2.1.0",
     "@peerbit/trusted-network": "^4.1.110",
+    "ajv": "^8.17.1",
     "bip39": "^3.1.0",
     "idb-keyval": "^6.2.2",
     "libsodium-wrappers": "^0.7.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@peerbit/trusted-network':
         specifier: ^4.1.110
         version: 4.1.110(react-native@0.79.2(@babel/core@7.27.4)(react@19.1.0))
+      ajv:
+        specifier: ^8.17.1
+        version: 8.17.1
       bip39:
         specifier: ^3.1.0
         version: 3.1.0
@@ -1218,6 +1221,9 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
+  ajv@8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+
   anser@1.4.10:
     resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}
 
@@ -1741,6 +1747,9 @@ packages:
   fast-redact@3.5.0:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
     engines: {node: '>=6'}
+
+  fast-uri@3.0.6:
+    resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -2300,6 +2309,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -2879,6 +2891,10 @@ packages:
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   require-main-filename@2.0.0:
@@ -5148,6 +5164,13 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.17.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.0.6
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   anser@1.4.10: {}
 
   ansi-escapes@4.3.2:
@@ -5715,6 +5738,8 @@ snapshots:
   fast-levenshtein@2.0.6: {}
 
   fast-redact@3.5.0: {}
+
+  fast-uri@3.0.6: {}
 
   fastq@1.19.1:
     dependencies:
@@ -6471,6 +6496,8 @@ snapshots:
 
   json-schema-traverse@0.4.1: {}
 
+  json-schema-traverse@1.0.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
@@ -7215,6 +7242,8 @@ snapshots:
   regenerator-runtime@0.13.11: {}
 
   require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
 
   require-main-filename@2.0.0: {}
 

--- a/src/programs/site/defaults.ts
+++ b/src/programs/site/defaults.ts
@@ -1,0 +1,249 @@
+import { Role } from '../acl/rbac';
+import type { ContentCategoryData, ContentCategoryMetadataField } from './types';
+
+export const defaultSiteRoles = [
+  new Role('moderator', [
+    'release:create',
+    'release:edit:any',
+    'release:delete',
+    'featured:manage',
+    'category:manage',
+    'blocklist:manage',
+    'subscription:manage',
+  ]),
+  new Role('member', [
+    'release:create',
+    'release:edit:own',
+  ]),
+];
+
+export const defaultSiteContentCategories: ContentCategoryData<ContentCategoryMetadataField>[] = [
+  {
+    categoryId: 'music',
+    displayName: 'Music',
+    featured: true,
+    metadataSchema: {
+      description: {
+        type: 'string',
+        description: 'Brief description of the music content',
+      },
+      totalSongs: {
+        type: 'number',
+        description: 'Total number of songs in this category',
+      },
+      totalDuration: {
+        type: 'string',
+        description: 'Total duration of all songs (e.g., in HH:MM:SS format)',
+      },
+      genres: {
+        type: 'array',
+        description: 'List of genres represented in this category',
+      },
+      tags: {
+        type: 'string',
+        description: 'Tags associated with the music release',
+      },
+      musicBrainzID: {
+        type: 'string',
+        description: 'MusicBrainz identifier for the release',
+      },
+      albumTitle: {
+        type: 'string',
+        description: 'Title of the album',
+      },
+      releaseYear: {
+        type: 'number',
+        description: 'Year of release',
+      },
+      releaseType: {
+        type: 'string',
+        description: 'Type of music release',
+        options: [
+          'Album',
+          'Soundtrack',
+          'EP',
+          'Anthology',
+          'Compilation',
+          'Single',
+          'Live Album',
+          'Remix',
+          'Bootleg',
+          'Interview',
+          'Mixtape',
+          'Demo',
+          'Concert Recording',
+          'DJ Mix',
+          'Unknown',
+        ],
+      },
+      fileFormat: {
+        type: 'string',
+        description: 'Audio file format',
+        options: ['MP3', 'FLAC', 'AAC', 'AC3', 'DTS'],
+      },
+      bitrate: {
+        type: 'string',
+        description: 'Audio bitrate (e.g., 320kbps)',
+      },
+      mediaFormat: {
+        type: 'string',
+        description: 'Physical media format if applicable',
+        options: ['CD', 'DVD', 'Vinyl', 'Soundboard', 'SACD', 'DAT', 'WEB', 'Blu-Ray'],
+      },
+    },
+  },
+  {
+    categoryId: 'videos',
+    displayName: 'Videos',
+    metadataSchema: {
+      title: {
+        type: 'string',
+        description: 'Title of the video',
+      },
+      description: {
+        type: 'string',
+        description: 'Brief description of the video content',
+      },
+      duration: {
+        type: 'string',
+        description: 'Length of the video (e.g., HH:MM:SS)',
+      },
+      resolution: {
+        type: 'string',
+        description: 'Video resolution (e.g., 1920x1080)',
+      },
+      format: {
+        type: 'string',
+        description: 'File format of the video (e.g., mp4, mov)',
+      },
+      tags: {
+        type: 'array',
+        description: 'User-defined tags for searchability (e.g., tutorial, vlog, funny)',
+      },
+      uploader: {
+        type: 'string',
+        description: 'Name or ID of the uploader/creator',
+      },
+      uploadDate: {
+        type: 'string',
+        description: 'Date the video was uploaded (e.g., YYYY-MM-DD)',
+      },
+      sourceUrl: {
+        type: 'string',
+        description: 'Original URL if sourced from an online platform (e.g., YouTube link)',
+      },
+    },
+  },
+  {
+    categoryId: 'movies',
+    displayName: 'Movies',
+    featured: true,
+    metadataSchema: {
+      description: {
+        type: 'string',
+        description: 'Brief description of the movie',
+      },
+      resolution: {
+        type: 'string',
+        description: 'Video resolution (e.g., 1920x1080)',
+      },
+      format: {
+        type: 'string',
+        description: 'File format of the video (e.g., mp4, mov)',
+      },
+      genres: {
+        type: 'array',
+        description: 'Genres associated with the video (e.g., action, drama)',
+      },
+      tags: {
+        type: 'array',
+        description: 'User-defined tags for searchability (e.g., funny, tutorial)',
+      },
+      posterCID: {
+        type: 'string',
+        description: 'Content ID for the movie poster',
+      },
+      TMDBID: {
+        type: 'string',
+        description: 'The Movie Database identifier',
+      },
+      IMDBID: {
+        type: 'string',
+        description: 'Internet Movie Database identifier',
+      },
+      releaseType: {
+        type: 'string',
+        description: 'Type of movie release',
+      },
+      releaseYear: {
+        type: 'number',
+        description: 'Year of release',
+      },
+      classification: {
+        type: 'string',
+        description: 'Content rating/classification (e.g., PG-13)',
+      },
+      duration: {
+        type: 'string',
+        description: 'Length of the movie',
+      },
+    },
+  },
+  {
+    categoryId: 'tv-shows',
+    displayName: 'TV Shows',
+    featured: true,
+    metadataSchema: {
+      description: {
+        type: 'string',
+        description: 'Brief description of the TV show',
+      },
+      seasons: {
+        type: 'number',
+        description: 'Number of seasons in the TV show',
+      },
+      totalEpisodes: {
+        type: 'number',
+        description: 'Total number of episodes aired across all seasons',
+      },
+      genres: {
+        type: 'array',
+        description: 'Genres associated with the TV show (e.g., comedy, sci-fi)',
+      },
+      firstAiredYear: {
+        type: 'number',
+        description: 'Year the TV show first aired',
+      },
+      status: {
+        type: 'string',
+        description: 'Current status of the TV show',
+        options: ['Returning Series', 'Ended', 'Canceled', 'In Production', 'Pilot', 'Unknown'],
+      },
+      TMDBID: {
+        type: 'string',
+        description: 'The Movie Database identifier for the TV show',
+      },
+      IMDBID: {
+        type: 'string',
+        description: 'Internet Movie Database identifier for the TV show',
+      },
+      posterCID: {
+        type: 'string',
+        description: 'Content ID for the TV show poster',
+      },
+      classification: {
+        type: 'string',
+        description: 'Content rating/classification (e.g., TV-MA, TV-14)',
+      },
+      network: {
+        type: 'string',
+        description: 'Original television network or streaming service',
+      },
+      averageEpisodeDuration: {
+        type: 'string',
+        description: 'Average duration of an episode (e.g., ~45 min, 00:45:00)',
+      },
+    },
+  },
+];
+

--- a/src/programs/site/index.ts
+++ b/src/programs/site/index.ts
@@ -2,3 +2,4 @@ export * from './lib';
 export * from './schemas';
 export * from './program';
 export * from './types';
+export * from './defaults';

--- a/src/programs/site/schemas/content-category.ts
+++ b/src/programs/site/schemas/content-category.ts
@@ -1,7 +1,7 @@
 import { variant, field, option } from '@dao-xyz/borsh';
 import type { ContentCategoryData, DocumentArgs } from '../types';
-import { v4 as uuid } from 'uuid';
-import { PublicSignKey } from '@peerbit/crypto';
+import { PublicSignKey, sha256Base64Sync } from '@peerbit/crypto';
+import { concat } from 'uint8arrays';
 
 @variant('content_category')
 export class ContentCategory {
@@ -13,6 +13,9 @@ export class ContentCategory {
 
   @field({ type: 'string' })
   siteAddress: string;
+
+  @field({ type: 'string' })
+  categoryId: string;
 
   @field({ type: 'string' })
   displayName: string;
@@ -27,11 +30,15 @@ export class ContentCategory {
   metadataSchema?: string;
 
   constructor(props: DocumentArgs<ContentCategoryData>) {
-    this.id = props.id ?? uuid();
+    this.id = props.id ?? sha256Base64Sync(concat([
+      new TextEncoder().encode(props.siteAddress),
+      new TextEncoder().encode(props.categoryId),
+    ]));
     this.postedBy = props.postedBy;
     this.siteAddress = props.siteAddress;
+    this.categoryId = props.categoryId;
     this.displayName = props.displayName;
-    this.featured = props.featured;
+    this.featured = props.featured ?? false;
     if (props.description) {
       this.description = props.description;
     }
@@ -50,6 +57,9 @@ export class IndexedContentCategory {
 
   @field({ type: 'string' })
   siteAddress: string;
+
+  @field({ type: 'string' })
+  categoryId: string;
 
   @field({ type: 'string' })
   displayName: string;
@@ -77,6 +87,7 @@ export class IndexedContentCategory {
     this.id = props.doc.id;
     this.postedBy = props.doc.postedBy.bytes;
     this.siteAddress = props.doc.siteAddress;
+    this.categoryId = props.doc.categoryId;
     this.displayName = props.doc.displayName;
     this.featured = props.doc.featured;
     this.description = props.doc.description;

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1,6 +1,7 @@
 import type { WithContext } from '@peerbit/document';
 import type { Site } from '../programs/site/program';
 import type {
+  ContentCategoryData,
   FeaturedReleaseData,
   ImmutableProps,
   ReleaseData,
@@ -8,7 +9,7 @@ import type {
   SubscriptionData,
   WithOptionalPostedBy,
 } from '../programs/site/types';
-import type { FeaturedRelease, Release, Subscription } from '../programs/site/schemas';
+import type { ContentCategory, FeaturedRelease, Release, Subscription } from '../programs/site/schemas';
 import type { SearchOptions } from '../common/types';
 import type { PublicSignKey } from '@peerbit/crypto';
 
@@ -26,9 +27,9 @@ export interface HashResponse extends IdResponse {
 }
 
 export interface AccountStatusResponse {
-    isAdmin: boolean;
-    roles: string[];
-    permissions: string[];
+  isAdmin: boolean;
+  roles: string[];
+  permissions: string[];
 }
 
 export type AddInput<T> = WithOptionalPostedBy<T>;
@@ -40,40 +41,35 @@ export interface ILensService {
   stop: () => Promise<void>;
   openSite: (siteOrAddress: Site | string, options: { siteArgs?: SiteArgs, federate?: boolean }) => Promise<void>;
   getAccountStatus: () => Promise<AccountStatusResponse>;
+
+  // Release Methods
   getRelease: (id: string) => Promise<WithContext<Release> | undefined>;
   getReleases: (options?: SearchOptions) => Promise<WithContext<Release>[]>;
-  getFeaturedRelease: (id: string) => Promise<WithContext<FeaturedRelease> | undefined>;
-  getFeaturedReleases: (options?: SearchOptions) => Promise<WithContext<FeaturedRelease>[]>;
   addRelease: (data: AddInput<ReleaseData>) => Promise<HashResponse>;
-  // Admin methods
   editRelease: (data: EditInput<ReleaseData>) => Promise<HashResponse>;
   deleteRelease: (id: string) => Promise<IdResponse>;
+
+  // Featured Release Methods
+  getFeaturedRelease: (id: string) => Promise<WithContext<FeaturedRelease> | undefined>;
+  getFeaturedReleases: (options?: SearchOptions) => Promise<WithContext<FeaturedRelease>[]>;
   addFeaturedRelease: (data: AddInput<FeaturedReleaseData>) => Promise<HashResponse>;
   editFeaturedRelease: (data: EditInput<FeaturedReleaseData>) => Promise<HashResponse>;
   deleteFeaturedRelease: (id: string) => Promise<IdResponse>;
+
+  // Category Methods
+  getContentCategory: (id: string) => Promise<WithContext<ContentCategory> | undefined>;
+  getContentCategories: (options?: SearchOptions) => Promise<WithContext<ContentCategory>[]>;
+  addContentCategory: (data: AddInput<ContentCategoryData>) => Promise<HashResponse>;
+  editContentCategory: (data: EditInput<ContentCategoryData>) => Promise<HashResponse>;
+  deleteContentCategory: (id: string) => Promise<IdResponse>;
+
+  // Subscription Methods
   getSubscriptions: (options?: SearchOptions) => Promise<Subscription[]>;
   addSubscription: (data: AddInput<SubscriptionData>) => Promise<HashResponse>;
   deleteSubscription: (data: { id?: string, to?: string }) => Promise<IdResponse>;
-  /**
-   * Assigns a specific role to a user.
-   * This is a privileged action that can only be performed by an admin.
-   * @param publicKey The public key of the user.
-   * @param roleId The string identifier of the role to assign (e.g., "member", "moderator").
-   */
+
+  // Admin and RBAC Methods
   assignRole(publicKey: string | PublicSignKey, roleId: string): Promise<BaseResponse>;
-
-  /**
-   * Revokes a specific role from a user.
-   * This is a privileged action that can only be performed by an admin.
-   * @param publicKey The public key of the user.
-   * @param roleId The string identifier of the role to revoke.
-   */
   revokeRole(publicKey: string | PublicSignKey, roleId: string): Promise<BaseResponse>;
-
-  /**
-   * Promotes a user to a full administrator.
-   * This is a privileged action that can only be performed by an existing admin.
-   * @param publicKey The public key of the user to promote.
-   */
   addAdmin(publicKey: string | PublicSignKey): Promise<BaseResponse>;
 }


### PR DESCRIPTION
### Overview

This pull request introduces comprehensive management for `ContentCategory` documents within the Lens SDK. It provides a complete, end-to-end implementation, from the core program logic to the high-level service API and testing.

### Key Features

1.  **Full CRUD Operations:** Adds `add`, `edit`, `delete`, and `get` methods for `ContentCategory` to the `LensService`, protected by the `'category:manage'` permission.
2.  **Immutable Business Key:** Establishes the `categoryId` field as an immutable "business key" to ensure data integrity for linked `Release` documents. The service layer's `editContentCategory` method now prevents this field from being changed.
3.  **Default Category Initialization:** Implements a new `initializeDefaultContentCategories` method, callable only by the site's root administrator. This allows for bootstrapping a new site with a default or custom set of categories.
4.  **Robust Schemas and Types:** Defines strong types and a new `defaults.ts` file for default category data, improving developer experience and type safety.

### Implementation Details

-   The `ContentCategory` schema now uses a deterministic, Base64-encoded hash of the `siteAddress` and `categoryId` as its unique `string` ID.
-   The `_verifyImmutableProperties` helper in `LensService` has been made more generic to handle checking additional immutable keys, such as `categoryId`.
-   Comprehensive end-to-end tests have been added in `site-permissions.e2e.test.ts` to verify RBAC permissions and the immutability constraint.
-   Unit tests in `site-program.test.ts` validate the behavior of the `initializeDefaultContentCategories` method, including idempotency and admin-only access.

This feature is a critical step towards a fully functional content management system, providing the necessary structure for organizing and linking releases.