### PR TITLE
feat: Integrate custom wallet-based identities into LensService

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@peerbit/trusted-network": "^4.1.110",
     "ajv": "^8.17.1",
     "bip39": "^3.1.0",
+    "ethers": "^6.15.0",
     "idb-keyval": "^6.2.2",
     "libsodium-wrappers": "^0.7.15",
     "p-defer": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       bip39:
         specifier: ^3.1.0
         version: 3.1.0
+      ethers:
+        specifier: ^6.15.0
+        version: 6.15.0
       idb-keyval:
         specifier: ^6.2.2
         version: 6.2.2
@@ -137,6 +140,9 @@ importers:
         version: 8.35.0(eslint@9.29.0)(typescript@5.8.3)
 
 packages:
+
+  '@adraffy/ens-normalize@1.10.1':
+    resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -811,9 +817,16 @@ packages:
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/curves@1.2.0':
+    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
+
   '@noble/curves@1.9.2':
     resolution: {integrity: sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.3.2':
+    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
+    engines: {node: '>= 16'}
 
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -1097,6 +1110,9 @@ packages:
   '@types/node@22.15.32':
     resolution: {integrity: sha512-3jigKqgSjsH6gYZv2nEsqdXfZqIFGAV36XYYjf9KGZ3PSG+IhLecqPnI310RvjutyMwifE2hhhNEklOUrvx/wA==}
 
+  '@types/node@22.7.5':
+    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
+
   '@types/qrcode@1.5.5':
     resolution: {integrity: sha512-CdfBi/e3Qk+3Z/fXYShipBT13OJ2fDO2Q2w5CIP5anLTLIndQG9z6P1cnm+8zCWSpm5dnxMFd/uREtb0EXuQzg==}
 
@@ -1213,6 +1229,9 @@ packages:
 
   aes-js@3.0.0:
     resolution: {integrity: sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==}
+
+  aes-js@4.0.0-beta.5:
+    resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
 
   agent-base@7.1.3:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
@@ -1690,6 +1709,10 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  ethers@6.15.0:
+    resolution: {integrity: sha512-Kf/3ZW54L4UT0pZtsY/rf+EkBU7Qi5nnhonjUb8yTXcxH3cdcWrV2cRyk0Xk/4jK6OoHhxxZHriyhje20If2hQ==}
+    engines: {node: '>=14.0.0'}
 
   event-iterator@2.0.0:
     resolution: {integrity: sha512-KGft0ldl31BZVV//jj+IAIGCxkvvUkkON+ScH6zfoX+l+omX6001ggyRSpI0Io2Hlro0ThXotswCtfzS8UkIiQ==}
@@ -3197,6 +3220,9 @@ packages:
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
+  tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -3247,6 +3273,9 @@ packages:
 
   uint8arrays@5.1.0:
     resolution: {integrity: sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==}
+
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -3359,6 +3388,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.17.1:
+    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   ws@8.18.2:
     resolution: {integrity: sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==}
     engines: {node: '>=10.0.0'}
@@ -3405,6 +3446,8 @@ packages:
     engines: {node: '>=10'}
 
 snapshots:
+
+  '@adraffy/ens-normalize@1.10.1': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -4493,9 +4536,15 @@ snapshots:
 
   '@noble/ciphers@1.3.0': {}
 
+  '@noble/curves@1.2.0':
+    dependencies:
+      '@noble/hashes': 1.3.2
+
   '@noble/curves@1.9.2':
     dependencies:
       '@noble/hashes': 1.8.0
+
+  '@noble/hashes@1.3.2': {}
 
   '@noble/hashes@1.8.0': {}
 
@@ -5004,6 +5053,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@22.7.5':
+    dependencies:
+      undici-types: 6.19.8
+
   '@types/qrcode@1.5.5':
     dependencies:
       '@types/node': 22.15.32
@@ -5154,6 +5207,8 @@ snapshots:
   acorn@8.15.0: {}
 
   aes-js@3.0.0: {}
+
+  aes-js@4.0.0-beta.5: {}
 
   agent-base@7.1.3: {}
 
@@ -5684,6 +5739,19 @@ snapshots:
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
+
+  ethers@6.15.0:
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.1
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@types/node': 22.7.5
+      aes-js: 4.0.0-beta.5
+      tslib: 2.7.0
+      ws: 8.17.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   event-iterator@2.0.0: {}
 
@@ -7519,6 +7587,8 @@ snapshots:
 
   tslib@1.14.1: {}
 
+  tslib@2.7.0: {}
+
   tslib@2.8.1: {}
 
   tsyringe@4.10.0:
@@ -7565,6 +7635,8 @@ snapshots:
   uint8arrays@5.1.0:
     dependencies:
       multiformats: 13.3.7
+
+  undici-types@6.19.8: {}
 
   undici-types@6.21.0: {}
 
@@ -7659,6 +7731,8 @@ snapshots:
       async-limiter: 1.0.1
 
   ws@7.5.10: {}
+
+  ws@8.17.1: {}
 
   ws@8.18.2: {}
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,12 +1,16 @@
+import type { Identity} from '@peerbit/crypto';
 import {
   Ed25519PublicKey,
   fromHexString,
+  PreHash,
   Secp256k1PublicKey,
+  SignatureWithKey,
   type PublicSignKey,
 } from '@peerbit/crypto';
 import { SearchRequest } from '@peerbit/document';
 import type { Access, IdentityAccessController} from '@peerbit/identity-access-controller';
 import { PublicKeyAccessCondition } from '@peerbit/identity-access-controller';
+import type { Signer } from 'ethers';
 
 const KEY_TYPES = {
   'ed25119p': {
@@ -64,4 +68,42 @@ export async function findAccessGrant(
     doc.accessCondition instanceof PublicKeyAccessCondition &&
     doc.accessCondition.key.equals(publicKey),
   );
+}
+
+/**
+ * Creates a Peerbit-compatible Identity from an ethers.js Signer (like a Wallet or browser provider).
+ * This allows users to sign Peerbit operations using their existing Ethereum wallet.
+ * @param signer An ethers.js Signer instance.
+ * @returns A promise that resolves to a Peerbit Identity object.
+ */
+export async function createIdentityFromSigner(signer: Signer): Promise<Identity<Secp256k1PublicKey>> {
+  // We force the wallet to sign a dummy message to recover the public key.
+  // This is a standard way to derive the public key from an ethers Signer.
+  const walletPublicKey = await Secp256k1PublicKey.recover(signer);
+
+  // From the signer, we can create a Peerbit-compatible identity.
+  const walletIdentity: Identity<Secp256k1PublicKey> = {
+    publicKey: walletPublicKey,
+
+    // The sign function bridges the ethers signing method with Peerbit's expected format.
+    sign: async (bytes: Uint8Array): Promise<SignatureWithKey> => {
+      // Ethereum wallets expect to sign the keccak256 hash of the message.
+      // Peerbit's `sign` method passes the raw bytes, so we let the wallet handle hashing internally.
+      // The `signer.signMessage` method does this automatically.
+      const signatureString = await signer.signMessage(bytes);
+
+      // peerbit/crypto expects the UTF-8 bytes of the hex signature string,
+      // not the actual signature bytes. We use TextEncoder to match this expectation.
+      const signatureBytes = new TextEncoder().encode(signatureString);
+
+      // We wrap the signature and public key in Peerbit's `SignatureWithKey` format.
+      return new SignatureWithKey({
+        prehash: PreHash.ETH_KECCAK_256,
+        publicKey: walletPublicKey,
+        signature: signatureBytes,
+      });
+    },
+  };
+
+  return walletIdentity;
 }

--- a/src/programs/site/types.ts
+++ b/src/programs/site/types.ts
@@ -8,9 +8,6 @@ export type ImmutableProps = {
   siteAddress: string;
 }
 
-export type WithOptionalId<T> = T & { id?: string };
-export type WithOptionalPostedBy<T> = T & { postedBy?: PublicSignKey };
-
 export type DocumentArgs<T> = T & Omit<ImmutableProps, 'id'> & { id?: string };
 
 export type ReleaseData<T = string> = {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -7,11 +7,11 @@ import type {
   ReleaseData,
   SiteArgs,
   SubscriptionData,
-  WithOptionalPostedBy,
 } from '../programs/site/types';
 import type { ContentCategory, FeaturedRelease, Release, Subscription } from '../programs/site/schemas';
 import type { SearchOptions } from '../common/types';
-import type { PublicSignKey } from '@peerbit/crypto';
+import type { Identity, PublicSignKey, Secp256k1PublicKey } from '@peerbit/crypto';
+import type { ProgramClient } from '@peerbit/program';
 
 export interface BaseResponse {
   success: boolean;
@@ -32,9 +32,16 @@ export interface AccountStatusResponse {
   permissions: string[];
 }
 
-export type AddInput<T> = WithOptionalPostedBy<T>;
+export type AddInput<T> = T;
 
 export type EditInput<T> = T & ImmutableProps;
+
+export type LensServiceOptions = { 
+  peerbit?: ProgramClient; 
+  debug?: boolean, 
+  customPrefix?: string,
+  identity?: Identity<Secp256k1PublicKey>
+};
 
 export interface ILensService {
   init: (directory?: string) => Promise<void>;

--- a/tests/wallet-identity.e2e.test.ts
+++ b/tests/wallet-identity.e2e.test.ts
@@ -1,0 +1,90 @@
+import { TestSession } from '@peerbit/test-utils';
+import { LensService } from '../src/services';
+import { Site } from '../src/programs/site';
+import { Wallet } from 'ethers';
+import { createIdentityFromSigner } from '../src/common/utils';
+import { waitFor, waitForResolved } from '@peerbit/time';
+
+describe('Custom Wallet Identity E2E', () => {
+  let session: TestSession;
+  let adminService: LensService;
+  let walletService: LensService;
+  let siteAddress: string;
+
+  beforeAll(async () => {
+    // 1. Setup a session with two peers. One for admin, one to host the wallet service.
+    session = await TestSession.connected(2);
+    const [adminClient, walletClient] = session.peers;
+
+    // 2. Create the admin service and open a new site.
+    adminService = new LensService({ peerbit: adminClient });
+    const site = new Site(adminClient.identity.publicKey);
+    await adminService.openSite(site);
+    siteAddress = adminService.siteProgram!.address;
+
+    // 3. Create a wallet-based identity for the second peer.
+    const wallet = Wallet.createRandom();
+    const walletIdentity = await createIdentityFromSigner(wallet);
+
+    // 4. Create the LensService instance, injecting the custom wallet identity.
+    walletService = new LensService({
+      peerbit: walletClient, // It uses walletClient for network connection
+      identity: walletIdentity, // But all actions are signed by walletIdentity
+    });
+    await walletService.openSite(siteAddress);
+
+    // 5. Wait for peers to be aware of each other in the site program.
+    await adminService.siteProgram!.waitFor(walletClient.peerId);
+  }, 30000);
+
+  afterAll(async () => {
+    await adminService.stop();
+    await walletService.stop();
+    await session.stop();
+  });
+
+  it('a user with a wallet identity cannot add a release without permissions', async () => {
+    const response = await walletService.addRelease({
+      name: 'Unauthorized Release',
+      categoryId: 'test',
+      contentCID: 'cid-fail',
+    });
+
+    expect(response.success).toBe(false);
+    expect(response.error).toContain('Access denied');
+  });
+
+  it('an admin can grant a role to the wallet\'s public key', async () => {
+    const walletPublicKey = walletService['_activeIdentity']!.publicKey;
+    const response = await adminService.assignRole(walletPublicKey, 'member');
+
+    expect(response.success).toBe(true);
+
+    // Verify the wallet user's status is now 'member'
+    await waitForResolved(async () => {
+      const status = await walletService.getAccountStatus();
+      expect(status.roles).toContain('member');
+    });
+  });
+
+  it('a user with a wallet identity CAN add a release after being granted a role', async () => {
+    const releaseData = {
+      name: 'My Wallet-Signed Release',
+      categoryId: 'music',
+      contentCID: 'cid-success',
+    };
+    const response = await walletService.addRelease(releaseData);
+
+    expect(response.success).toBe(true);
+    expect(response.id).toBeDefined();
+
+    // Verify the release exists and was posted by the correct identity
+    const newRelease = await waitFor(() => adminService.getRelease(response.id!));
+    expect(newRelease).toBeDefined();
+    expect(newRelease!.name).toEqual(releaseData.name);
+
+    // CRITICAL: Check that the `postedBy` field matches the wallet's public key
+    const walletPublicKey = walletService['_activeIdentity']!.publicKey;
+    expect(newRelease!.postedBy.equals(walletPublicKey)).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR introduces a major enhancement to `LensService`, allowing it to be instantiated with a custom, wallet-based `Identity` (e.g., from MetaMask via ethers.js). This enables users to sign for all database operations using their own wallet, rather than relying on the anonymous, ephemeral identity of the underlying Peerbit node.

#### Key Changes:

*   **Custom Identity in `LensService`**: The `LensService` constructor now accepts an optional `identity` property. If provided, this identity will be used for all subsequent write operations (`put`/`del`).
*   **Signer Abstraction**: A new private method `_getActiveSigner()` has been added to conditionally provide the `signers` option to database methods only when a custom identity is present.
*   **Correct Identity Attribution**:
    *   All "add" methods (e.g., `addRelease`) now correctly set the `postedBy` field to the public key of the active identity (custom or default).
    *   `getAccountStatus` now correctly checks the permissions for the active identity, providing an accurate status to the end-user.
*   **Type Safety**: The `AddInput<T>` type has been refined to no longer include an optional `postedBy` field, enforcing that the service is the sole authority for this property and creating a safer, more intuitive API.
*   **Comprehensive Testing**: A new E2E test suite (`wallet-identity.e2e.test.ts`) has been added to validate the entire workflow:
    *   Verifies that a wallet user is initially denied access.
    *   Confirms an admin can grant roles to the wallet's public key.
    *   Ensures the wallet user can perform actions after being granted permission.
    *   Asserts that created documents are correctly attributed to the wallet's public key.

This change significantly improves the usability and security of the SDK for dApp development by providing a non-custodial, user-centric approach to identity and access control.
