### PR TITLE
fix(rbac): Ensure robust initialization and add role discovery API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@riffcc/lens-sdk",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "type": "module",
   "files": [
     "dist"

--- a/src/programs/acl/rbac/program.ts
+++ b/src/programs/acl/rbac/program.ts
@@ -137,6 +137,16 @@ export class RoleBasedccessController extends Program<Args> {
   }
 
   /**
+ * Retrieves all defined roles from the roles database.
+ * This is a public read operation and can be performed by any user.
+ * @returns A promise that resolves to an array of all Role documents.
+ */
+  async getRoles(): Promise<Role[]> {
+    // A search with an empty query object fetches all documents.
+    return this.roles.index.search(new SearchRequest({}));
+  }
+
+  /**
    * Grants another peer full administrative privileges.
    * This is a privileged action that can only be performed by an existing admin.
    * @param admin The PublicSignKey of the peer to promote to an admin.

--- a/src/programs/acl/rbac/program.ts
+++ b/src/programs/acl/rbac/program.ts
@@ -102,9 +102,13 @@ export class RoleBasedccessController extends Program<Args> {
       },
     });
 
+  }
+
+  async afterOpen() {
+    await super.afterOpen();
     // Only the root admin should be responsible for initializing the system.
     if (this.node.identity.publicKey.equals(this.admins.rootTrust)) {
-      await this._initializeDefaultRoles();
+      await this._initDefaultRoles();
     }
   }
 
@@ -112,8 +116,8 @@ export class RoleBasedccessController extends Program<Args> {
    * Idempotently creates the default roles if they don't already exist.
    * This is a private method only called by the root admin upon opening.
    */
-  private async _initializeDefaultRoles(): Promise<void> {
-    if (this._defaultRoles.length === 0) {
+  private async _initDefaultRoles(): Promise<void> {
+    if (!this._defaultRoles || this._defaultRoles.length === 0) {
       return;
     }
     for (const defaultRole of this._defaultRoles) {

--- a/src/programs/site/program.ts
+++ b/src/programs/site/program.ts
@@ -9,6 +9,7 @@ import { type SiteArgs } from './types';
 import { BlockedContent, ContentCategory, FeaturedRelease, IndexedBlockedContent, IndexedContentCategory, IndexedFeaturedRelease, IndexedRelease, IndexedSubscription, Release, Subscription } from './schemas';
 import { RoleBasedccessController } from '../acl/rbac/program';
 import { defaultSiteContentCategories, defaultSiteRoles } from './defaults';
+import type { Role } from '../acl/rbac';
 
 @variant('site')
 export class Site extends Program<SiteArgs> {
@@ -34,7 +35,7 @@ export class Site extends Program<SiteArgs> {
     return `${this.address}/federation`;
   }
 
-  constructor(rootTrust: PublicSignKey) {
+  constructor(props: { rootAdmin: PublicSignKey; defaultRoles?: Role[] }) {
     super();
     this.releases = new Documents();
     this.featuredReleases = new Documents();
@@ -42,8 +43,8 @@ export class Site extends Program<SiteArgs> {
     this.subscriptions = new Documents();
     this.blockedContent = new Documents();
     this.access = new RoleBasedccessController({
-      rootAdmin: rootTrust,
-      defaultRoles: defaultSiteRoles,
+      rootAdmin: props.rootAdmin,
+      defaultRoles: props.defaultRoles ?? defaultSiteRoles,
     });
   }
 
@@ -263,7 +264,7 @@ export class Site extends Program<SiteArgs> {
  * This is a public method that can only be successfully called by the site's root administrator.
  * @param initialCategories An optional array of categories to use instead of the defaults.
  */
-  async initializeDefaultContentCategories(
+  async initContentCategories(
     initialCategories: ContentCategoryData<ContentCategoryMetadataField>[] = defaultSiteContentCategories,
   ): Promise<void> {
     if (!this.node.identity.publicKey.equals(this.access.admins.rootTrust)) {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -12,6 +12,7 @@ import type { ContentCategory, FeaturedRelease, Release, Subscription } from '..
 import type { SearchOptions } from '../common/types';
 import type { Identity, PublicSignKey, Secp256k1PublicKey } from '@peerbit/crypto';
 import type { ProgramClient } from '@peerbit/program';
+import type { Role } from '../programs/acl/rbac';
 
 export interface BaseResponse {
   success: boolean;
@@ -75,7 +76,8 @@ export interface ILensService {
   addSubscription: (data: AddInput<SubscriptionData>) => Promise<HashResponse>;
   deleteSubscription: (data: { id?: string, to?: string }) => Promise<IdResponse>;
 
-  // Admin and RBAC Methods
+  // ACL Methods
+  getRoles(): Promise<Role[]>;
   assignRole(publicKey: string | PublicSignKey, roleId: string): Promise<BaseResponse>;
   revokeRole(publicKey: string | PublicSignKey, roleId: string): Promise<BaseResponse>;
   addAdmin(publicKey: string | PublicSignKey): Promise<BaseResponse>;

--- a/tests/federation-benchmark.mjs
+++ b/tests/federation-benchmark.mjs
@@ -8,8 +8,8 @@ import { Site, LensService } from '../dist/index.mjs';
  */
 const createNewSite = (peerbit) => {
   // The peerbit's public key is used as the root of trust for the new site's access control.
-  const rootTrust = peerbit.identity.publicKey;
-  return new Site(rootTrust);
+  const rootAdmin = peerbit.identity.publicKey;
+  return new Site({ rootAdmin });
 };
 
 /**

--- a/tests/federation.e2e.test.ts
+++ b/tests/federation.e2e.test.ts
@@ -17,8 +17,8 @@ import { waitForResolved } from '@peerbit/time';
       serviceB = new LensService({ peerbit: session.peers[1] });
       
       // 4. Create and open the sites. This part remains the same.
-      const siteA = new Site(serviceA.peerbit!.identity.publicKey);
-      const siteB = new Site(serviceB.peerbit!.identity.publicKey);
+      const siteA = new Site({ rootAdmin: serviceA.peerbit!.identity.publicKey });
+      const siteB = new Site({ rootAdmin: serviceB.peerbit!.identity.publicKey });
       
       // Both services need federation enabled to broadcast and listen.
       await serviceA.openSite(siteA, { federate: true });

--- a/tests/site-permissions.e2e.test.ts
+++ b/tests/site-permissions.e2e.test.ts
@@ -2,7 +2,7 @@ import { TestSession } from '@peerbit/test-utils';
 import type { ProgramClient } from '@peerbit/program';
 import { Site } from '../src/programs/site/program';
 import type { ContentCategoryData, ReleaseData } from '../src/programs/site/types';
-import { waitFor, waitForResolved } from '@peerbit/time';
+import { delay, waitFor, waitForResolved } from '@peerbit/time';
 import { LensService } from '../src/services';
 
 // --- Test Helpers ---
@@ -91,6 +91,7 @@ describe('Role-Based Access Control (RBAC) in Site', () => {
       const releaseResp = await memberService.addRelease(createReleaseData());
       expect(releaseResp.success).toBe(true);
       await waitFor(() => adminService.getRelease(releaseResp.id!));
+      await delay(1000);
       const deleteResp = await adminService.deleteRelease(releaseResp.id!);
       expect(deleteResp.success).toBe(true);
     });
@@ -226,9 +227,7 @@ describe('Role-Based Access Control (RBAC) in Site', () => {
     it('cannot edit a release created by another user', async () => {
       const moderatorReleaseResp = await moderatorService.addRelease(createReleaseData());
       expect(moderatorReleaseResp.success).toBe(true);
-      await waitFor(() => memberService.getRelease(moderatorReleaseResp.id!));
-
-      const releaseToEdit = await memberService.getRelease(moderatorReleaseResp.id!);
+      const releaseToEdit = await waitFor(() => memberService.getRelease(moderatorReleaseResp.id!));
       const editInput = {
         id: releaseToEdit!.id,
         name: 'Attempted Edit by Member',

--- a/tests/site-permissions.e2e.test.ts
+++ b/tests/site-permissions.e2e.test.ts
@@ -45,7 +45,7 @@ describe('Role-Based Access Control (RBAC) in Site', () => {
     memberService = new LensService({ peerbit: memberClient });
     guestService = new LensService({ peerbit: guestClient });
 
-    const site = new Site(adminClient.identity.publicKey);
+    const site = new Site({ rootAdmin: adminClient.identity.publicKey });
     await adminService.openSite(site);
     siteAddress = adminService.siteProgram!.address;
 

--- a/tests/site-program.test.ts
+++ b/tests/site-program.test.ts
@@ -28,7 +28,7 @@ describe('Site Program', () => {
 
     // Open a new site before each test in this block
     beforeEach(async () => {
-      siteProgram = new Site(ownerClient.identity.publicKey);
+      siteProgram = new Site({ rootAdmin: ownerClient.identity.publicKey });
       await ownerClient.open(siteProgram);
     });
 
@@ -73,7 +73,7 @@ describe('Site Program', () => {
 
   describe('lifecycle management', () => {
     it('can be closed and reopened successfully', async () => {
-      const siteProgram = new Site(ownerClient.identity.publicKey);
+      const siteProgram = new Site({ rootAdmin: ownerClient.identity.publicKey });
 
       // 1. Initial open
       const openedProgram = await ownerClient.open(siteProgram);
@@ -104,7 +104,7 @@ describe('Site Program', () => {
     let siteProgram: Site;
 
     beforeEach(async () => {
-      siteProgram = new Site(ownerClient.identity.publicKey);
+      siteProgram = new Site({ rootAdmin: ownerClient.identity.publicKey });
       await ownerClient.open(siteProgram);
     });
 
@@ -120,7 +120,7 @@ describe('Site Program', () => {
       expect(initialSize).toBe(0);
 
       // 2. Call the initialization method directly on the program instance
-      await siteProgram.initializeDefaultContentCategories();
+      await siteProgram.initContentCategories();
 
       // 3. Wait for the documents to be added and assert the size
       await waitForResolved(async () => {
@@ -131,8 +131,8 @@ describe('Site Program', () => {
 
     it('initialization is idempotent', async () => {
       // Call the method twice
-      await siteProgram.initializeDefaultContentCategories();
-      await siteProgram.initializeDefaultContentCategories();
+      await siteProgram.initContentCategories();
+      await siteProgram.initContentCategories();
 
       // The size should still be the same as the default list, not doubled.
       await waitForResolved(async () => {
@@ -146,7 +146,7 @@ describe('Site Program', () => {
       const siteFromNonOwner = await noOwnerClient.open<Site>(siteProgram.address);
 
       // Expect the call to fail because the non-admin is not the root trust.
-      await expect(siteFromNonOwner.initializeDefaultContentCategories()).rejects.toThrow(
+      await expect(siteFromNonOwner.initContentCategories()).rejects.toThrow(
         'Only the root administrator can initialize default content categories.',
       );
 

--- a/tests/wallet-identity.e2e.test.ts
+++ b/tests/wallet-identity.e2e.test.ts
@@ -18,7 +18,7 @@ describe('Custom Wallet Identity E2E', () => {
 
     // 2. Create the admin service and open a new site.
     adminService = new LensService({ peerbit: adminClient });
-    const site = new Site(adminClient.identity.publicKey);
+    const site = new Site({ rootAdmin: adminClient.identity.publicKey });
     await adminService.openSite(site);
     siteAddress = adminService.siteProgram!.address;
 


### PR DESCRIPTION
### Summary

This pull request addresses a critical lifecycle bug in the `RoleBasedccessController` and enhances its API by adding a method to retrieve all available roles.

### The Bug: Initialization Failure on Remote Peers

Previously, the logic to create default roles was located in the `open()` method. This worked for the peer creating the program, but failed on remote peers opening the program from its address.

**Root Cause:** When a program is loaded from a serialized state (deserialized), its constructor is not called. This meant that the private `_defaultRoles` property was `undefined` on remote peers, causing a `TypeError: Cannot read properties of undefined (reading 'length')` when `open()` was executed.

### The Fix: Using the `afterOpen` Lifecycle Hook

1.  **Moved Logic to `afterOpen`:** The default role initialization logic has been moved from `open()` to the `afterOpen()` lifecycle hook. This hook is guaranteed to run after the program and all its sub-programs are fully initialized, on every peer.
2.  **Calling `super.afterOpen()`:** The implementation correctly calls `super.afterOpen()` to ensure the base `Program` class's critical setup (network listeners, event dispatching) is always executed.
3.  **Handling `undefined`:** A guard (`if (!this._defaultRoles)`) has been added to safely handle the case where the property is `undefined` on deserialized instances.

This change makes the RBAC controller robust and ensures it initializes correctly across the entire network.

### New Feature: Role Discovery

To support UI development (e.g., for an admin panel), a new public method has been added:

-   `getRoles()` on `RoleBasedccessController`: Queries and returns all `Role` documents from the roles database.
-   `getRoles()` on `LensService`: Exposes this functionality through the public service layer API.

This allows clients to easily fetch a list of all available roles for tasks like populating a dropdown menu for role assignments.

### Other Changes

-   The `Site` program's constructor has been updated to accept a properties object (`{ rootAdmin, defaultRoles }`) for better extensibility. All tests have been updated accordingly.