### PR TITLE
feat(site-registry): Introduce a program for site discovery and registration

### DIFF
--- a/src/programs/site-registry/index.ts
+++ b/src/programs/site-registry/index.ts
@@ -1,0 +1,2 @@
+export * from './program';
+export * from './schemas';

--- a/src/programs/site-registry/program.ts
+++ b/src/programs/site-registry/program.ts
@@ -1,0 +1,130 @@
+import { deserialize, field, fixedArray, variant } from '@dao-xyz/borsh';
+import { Program } from '@peerbit/program';
+import { Documents, type CanPerformOperations } from '@peerbit/document';
+import { sha256Sync } from '@peerbit/crypto';
+import type { Site } from '../site/program';
+import type { SiteManifest } from './schemas';
+import { SiteRegistration, IndexableSiteRegistration } from './schemas';
+import { concat } from 'uint8arrays';
+
+export const SITE_REGISTRY_ID_STRING = 'riffcc_sites_v1';
+export const SITE_REGISTRY_ID = sha256Sync(new TextEncoder().encode(SITE_REGISTRY_ID_STRING));
+
+@variant('site_registry')
+export class SiteRegistry extends Program {
+  @field({ type: fixedArray('u8', 32) })
+  id: Uint8Array;
+
+  @field({ type: Documents })
+  registrations: Documents<SiteRegistration, IndexableSiteRegistration>;
+
+  constructor(props?: { id?: Uint8Array; }) {
+    super();
+    this.id = props?.id ?? SITE_REGISTRY_ID;
+    this.registrations = new Documents({
+      id: sha256Sync(concat([
+        this.id,
+        new TextEncoder().encode('registrations'),
+      ])),
+    });
+  }
+
+  async open(): Promise<void> {
+    await this.registrations.open({
+      type: SiteRegistration,
+      replicate: { factor: 1 },
+      index: {
+        canRead: () => true,
+        type: IndexableSiteRegistration,
+        transform: (doc) => new IndexableSiteRegistration(doc),
+      },
+      // --- ACCESS CONTROL LOGIC ---
+      canPerform: async (op: CanPerformOperations<SiteRegistration>) => {
+        // The signer of the operation
+        const signer = op.entry.signatures[0].publicKey;
+
+        // Use the 'type' property to discriminate the union
+        if (op.type === 'put') {
+          // This is a create or update operation
+          const registration = deserialize(op.operation.data, SiteRegistration);
+
+          // Rule 1: The signer must be the owner of the registration.
+          if (!signer.equals(registration.owner)) {
+            return false;
+          }
+
+          // Rule 2: (For updates) Ensure the owner is not changed.
+          const existing = await this.registrations.index.get(registration.id);
+          if (existing && !existing.owner.equals(registration.owner)) {
+            return false;
+          }
+
+          return true;
+        }
+        else if (op.type === 'delete') { // Using else if for clarity
+          // This is a delete operation
+          // The key on DeleteOperation is an object { key: primitive }, so we need .key.key
+          const registrationId = op.operation.key.key;
+          const existing = await this.registrations.index.get(registrationId);
+
+          if (!existing) {
+            return true; // Deleting something that doesn't exist is OK.
+          }
+
+          // Rule 3: Only the owner can delete their registration.
+          if (!signer.equals(existing.owner)) {
+            return false;
+          }
+
+          return true;
+        }
+
+        // Fallback for any other potential operation types in the future
+        return false;
+      },
+    });
+  }
+
+  // --- Helper Methods ---
+
+  // A site owner publishes their site
+  async publishSite(site: Site, manifest: SiteManifest): Promise<SiteRegistration> {
+    // The owner is the root admin of the site program.
+    const owner = site.access.admins.rootTrust;
+
+    // Ensure the person calling this IS the owner
+    if (!this.node.identity.publicKey.equals(owner)) {
+      throw new Error('Only the site owner can publish its registration.');
+    }
+
+    const registration = new SiteRegistration({
+      owner,
+      manifest,
+      siteAddress: site.address,
+    });
+
+    await this.registrations.put(registration);
+    return registration;
+  }
+
+  async updateManifest(siteAddress: string, newManifest: SiteManifest): Promise<SiteRegistration> {
+    const owner = this.node.identity.publicKey;
+
+    // Re-calculate the deterministic ID to find the existing document
+    const registrationId = sha256Sync(concat([owner.bytes, new TextEncoder().encode(siteAddress)]));
+    const existing = await this.registrations.index.get(registrationId);
+
+    if (!existing) {
+      throw new Error(`Site registration for address ${siteAddress} by this owner not found.`);
+    }
+
+    const registration = new SiteRegistration({
+      owner,
+      manifest: newManifest,
+      siteAddress: siteAddress,
+    });
+
+    await this.registrations.put(registration);
+    return registration;
+  }
+}

--- a/src/programs/site-registry/schemas.ts
+++ b/src/programs/site-registry/schemas.ts
@@ -1,0 +1,101 @@
+import { field, fixedArray, option, variant } from '@dao-xyz/borsh';
+import { PublicSignKey, sha256Sync } from '@peerbit/crypto';
+import { concat } from 'uint8arrays';
+import { v4 as uuid } from 'uuid';
+
+@variant('site_manifest')
+export class SiteManifest {
+    @field({ type: 'string' })
+    id: string;
+
+    @field({ type: 'string' })
+    name: string;
+
+    @field({ type: option('string') })
+    description?: string;
+
+    @field({ type: option('string') })
+    icon?: string; 
+
+    @field({ type: option('string') })
+    url?: string; 
+
+    constructor(props: {
+        id?: string;
+        name: string;
+        description?: string;
+        icon?: string;
+        url?: string;
+    }) {
+        this.id = props.id ?? uuid();
+        this.name = props.name;
+        this.description = props.description;
+        this.icon = props.icon;
+        this.url = props.url;
+    }
+}
+
+export class IndexableSiteManifest {
+    @field({ type: 'string' })
+    id: string;
+    
+    @field({ type: 'string' })
+    name: string;
+
+    @field({ type: option('string') })
+    description?: string;
+
+    constructor(doc: SiteManifest) {
+        this.id = doc.id;
+        this.name = doc.name;
+        this.description = doc.description;
+    }
+}
+
+
+@variant('site_registration')
+export class SiteRegistration {
+    @field({ type: fixedArray('u8', 32) })
+    id: Uint8Array;
+
+    @field({ type: PublicSignKey })
+    owner: PublicSignKey;
+
+    @field({ type: SiteManifest })
+    manifest: SiteManifest;
+
+    @field({ type: 'string' })
+    siteAddress: string;
+
+    constructor(properties: {
+        owner: PublicSignKey;
+        manifest: SiteManifest;
+        siteAddress: string;
+    }) {
+        this.owner = properties.owner;
+        this.manifest = properties.manifest;
+        this.siteAddress = properties.siteAddress;
+        this.id = sha256Sync(concat([this.owner.bytes, new TextEncoder().encode(this.siteAddress)]));
+    }
+}
+
+export class IndexableSiteRegistration {
+    @field({ type: Uint8Array })
+    id: Uint8Array;
+
+    @field({ type: Uint8Array })
+    owner: Uint8Array;
+
+    @field({ type: 'string' })
+    name: string;
+
+    @field({ type: 'string' })
+    siteAddress: string;
+
+    constructor(doc: SiteRegistration) {
+        this.id = doc.id;
+        this.owner = doc.owner.bytes;
+        this.name = doc.manifest.name;
+        this.siteAddress = doc.siteAddress;
+    }
+}

--- a/tests/site-registry-program.test.ts
+++ b/tests/site-registry-program.test.ts
@@ -1,0 +1,145 @@
+import { TestSession } from '@peerbit/test-utils';
+import type { ProgramClient } from '@peerbit/program';
+import { waitForResolved } from '@peerbit/time';
+import { AccessError } from '@peerbit/crypto';
+import { Site } from '../src/programs/site/program';
+import { SiteRegistry } from '../src/programs/site-registry/program';
+import type { SiteRegistration } from '../src/programs/site-registry/schemas';
+import { SiteManifest } from '../src/programs/site-registry/schemas';
+
+describe('SiteRegistry Program', () => {
+  let session: TestSession;
+  let ownerClient: ProgramClient, otherClient: ProgramClient;
+  let ownerSite: Site;
+
+  // --- ONE-TIME SETUP for clients and a shared site ---
+  beforeAll(async () => {
+    session = await TestSession.connected(2);
+    [ownerClient, otherClient] = session.peers;
+
+    ownerSite = new Site({ rootAdmin: ownerClient.identity.publicKey });
+    await ownerClient.open(ownerSite);
+  }, 15000);
+
+  // --- ONE-TIME TEARDOWN ---
+  afterAll(async () => {
+    if (ownerSite && !ownerSite.closed) {
+      await ownerSite.close();
+    }
+    await session.stop();
+  });
+
+  // SCENARIO 1: A user successfully publishes, updates, and deletes a site.
+  describe('Lifecycle of a Registration', () => {
+    let registry: SiteRegistry;
+    let otherRegistry: SiteRegistry;
+    let registration: SiteRegistration; // This will hold the state across tests
+
+    // Setup the scenario once
+    beforeAll(async () => {
+      registry = new SiteRegistry();
+      await ownerClient.open(registry);
+      otherRegistry = await otherClient.open<SiteRegistry>(registry.address);
+      await registry.waitFor(otherClient.peerId);
+    });
+
+    // Tear down the scenario once
+    afterAll(async () => {
+      if (registry && !registry.closed) await registry.close();
+      if (otherRegistry && !otherRegistry.closed) await otherRegistry.close();
+    });
+
+    it('Step 1: The site owner publishes their site', async () => {
+      const manifest = new SiteManifest({ name: 'My Awesome Site' });
+      registration = await registry.publishSite(ownerSite, manifest);
+
+      expect(registration).toBeDefined();
+      expect(registration.owner.equals(ownerClient.identity.publicKey)).toBe(true);
+
+      const fetched = await registry.registrations.index.get(registration.id);
+      expect(fetched).toBeDefined();
+    });
+
+    it('Step 2: The published registration replicates to another peer', async () => {
+      await waitForResolved(async () => {
+        const fetched = await otherRegistry.registrations.index.get(registration.id);
+        expect(fetched).toBeDefined();
+        expect(fetched?.manifest.name).toEqual('My Awesome Site');
+      });
+    });
+
+    it('Step 3: The owner updates the manifest', async () => {
+      const newManifest = new SiteManifest({ name: 'Updated Name' });
+      await registry.updateManifest(ownerSite.address, newManifest);
+
+      const fetched = await registry.registrations.index.get(registration.id);
+      expect(fetched?.manifest.name).toEqual('Updated Name');
+
+      // Verify the update replicated
+      await waitForResolved(async () => {
+        const fetchedOnOtherPeer = await otherRegistry.registrations.index.get(registration.id);
+        expect(fetchedOnOtherPeer?.manifest.name).toEqual('Updated Name');
+      });
+    });
+
+    it('Step 4: The owner deletes their registration', async () => {
+      await registry.registrations.del(registration.id);
+
+      const sizeAfter = await registry.registrations.index.getSize();
+      expect(sizeAfter).toEqual(0);
+
+      // Verify deletion replicated
+      await waitForResolved(async () => {
+        const fetchedOnOtherPeer = await otherRegistry.registrations.index.get(registration.id);
+        expect(fetchedOnOtherPeer).toBeUndefined();
+      });
+    });
+  });
+
+
+  // SCENARIO 2: Testing access control rules with another user.
+  describe('Access Control', () => {
+    let registry: SiteRegistry;
+    let otherRegistry: SiteRegistry;
+    let registration: SiteRegistration; // State for this scenario
+
+    beforeAll(async () => {
+      registry = new SiteRegistry();
+      await ownerClient.open(registry);
+      otherRegistry = await otherClient.open<SiteRegistry>(registry.address);
+      await registry.waitFor(otherClient.peerId);
+
+      // Create a registration to test against
+      const manifest = new SiteManifest({ name: 'Protected Site' });
+      registration = await registry.publishSite(ownerSite, manifest);
+
+      // Ensure it's replicated before tests start
+      await waitForResolved(async () => {
+        expect(await otherRegistry.registrations.index.get(registration.id)).toBeDefined();
+      });
+    });
+
+    afterAll(async () => {
+      if (registry && !registry.closed) await registry.close();
+      if (otherRegistry && !otherRegistry.closed) await otherRegistry.close();
+    });
+
+
+    it('a non-owner cannot publish a site on behalf of the owner', async () => {
+      const manifest = new SiteManifest({ name: 'Imposter Site' });
+      await expect(otherRegistry.publishSite(ownerSite, manifest))
+        .rejects.toThrow('Only the site owner can publish its registration.');
+    });
+
+    it('a non-owner cannot update the manifest', async () => {
+      const newManifest = new SiteManifest({ name: 'Malicious Update' });
+      await expect(otherRegistry.updateManifest(ownerSite.address, newManifest))
+        .rejects.toThrow(`Site registration for address ${ownerSite.address} by this owner not found.`);
+    });
+
+    it('a non-owner cannot delete a registration', async () => {
+      await expect(otherRegistry.registrations.del(registration.id))
+        .rejects.toThrow(AccessError);
+    });
+  });
+});


### PR DESCRIPTION

This PR introduces the `SiteRegistry`, a new Peerbit program designed to act as a decentralized and discoverable index for `Site` programs. It allows site owners to publish a manifest for their site, making it findable by other users in the network.

The implementation is delivered in two commits: the first introduces the core program and its schemas, and the second adds comprehensive tests.

### Key Features & Implementation Details

*   **Deterministic Address**: The `SiteRegistry` is designed with a deterministic ID (`SITE_REGISTRY_ID`), allowing any peer to open and connect to the same registry instance without prior discovery.
*   **Robust Ownership and ID Strategy**: A `SiteRegistration`'s ID is a composite hash of the `owner`'s public key and the `siteAddress`. This cryptographically ensures that only one registration can exist per owner per site, preventing address "squatting".
*   **Secure Access Control**: The `canPerform` logic within the `Documents` store enforces strict ownership rules:
    -   Only the designated `owner` can publish or update their registration.
    -   Only the `owner` can delete their registration.
    -   An `owner` cannot be changed during an update.
*   **Modular Schema**: The `SiteManifest` is kept as a separate, nested object within the `SiteRegistration`, promoting a clean and reusable data model.

### How to Use

Peers can now open the `SiteRegistry` using its well-known ID and then use its helper methods to publish their own sites or discover others.

```typescript
// Any peer can open the registry
const registry = await client.open(new SiteRegistry());

// A site owner can publish their site
await registry.publishSite(mySite, new SiteManifest({ name: 'My Site' }));
```
```